### PR TITLE
Patch ActionsController to handle generic creates

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -6,10 +6,12 @@
   %tr
     %th Name
     %th Description
+    %th Badge
   - for campaign in @user.campaigns
     %tr
       %td= campaign.name
       %td= campaign.description
+      %td= image_tag campaign.individual_badge.url
 
 %hr/
 %h3 Actions

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -21,7 +21,7 @@
     %th
   - for action in @user.actions.desc(:created_at)
     %tr
-      %td= action.action_type
+      %td= action.action_type.try(:name)
       %td= action.channel.try(:name)
       %td= action.created_at
       


### PR DESCRIPTION
Creating actions via the API on a new channel type wasn't correctly
creating or initializing the user, looking up the channel, or looking up
the action_type. Copied the implementation from the email channel.
