### PR TITLE
Fix for admin sign-ins getting redirected to non-existent participants pages.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
 	def after_sign_in_path_for(resource)
-	 participant_path(resource)
+    if current_admin_user
+       admin_campaigns_url
+    else
+      participant_path(resource)
+    end
 	end
 end


### PR DESCRIPTION
Checks if user is admin and sends:
- Admin sign-in and sign-up redirect to admin pages.
- User sign-in and sign-up still goes to their participant page
